### PR TITLE
refactor: Set side of ding to CLIENT for Forge and Minecraft

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,6 @@
 modLoader="javafml"
 loaderVersion="[28,)" #forge version dep
+license="GNU Lesser General Public License v3.0"
 issueTrackerURL="https://github.com/iChun/BackTools/issues"
 
 [[mods]]
@@ -17,10 +18,10 @@ issueTrackerURL="https://github.com/iChun/BackTools/issues"
     mandatory=true
     versionRange="[28,)"
     ordering="NONE"
-    side="BOTH"
+    side="CLIENT"
 [[dependencies.backtools]]
     modId="minecraft"
     mandatory=true
     versionRange="[1.14.4]"
     ordering="NONE"
-    side="BOTH"
+    side="CLIENT"


### PR DESCRIPTION
A small change in the [[dependencies.backtools]] declaration which reflects the actual side of the mod when used. This will help ServerPackCreator identify the sideness in future upates.

For reference: Griefed/ServerPackCreator#70

Please let me know if you have any issues with this.

Cheers,
Griefed